### PR TITLE
Add nginx image for use within kubernetes clusters

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,149 @@
+FROM alpine:3.11
+
+LABEL maintainers="n@nikhilc.xyz"
+
+ENV NGINX_VERSION=1.18.0 VTS_MODULE_VERSION=0.1.18
+ENV APP_USER=nginx APP_DIR=/app
+
+# make a pipe fail on the first failure
+SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+
+# ensure we only use apk repositories over HTTPS (altough APK contain an embedded signature)
+RUN echo "https://alpine.global.ssl.fastly.net/alpine/v$(cut -d . -f 1,2 < /etc/alpine-release)/main" > /etc/apk/repositories \
+	&& echo "https://alpine.global.ssl.fastly.net/alpine/v$(cut -d . -f 1,2 < /etc/alpine-release)/community" >> /etc/apk/repositories
+
+# Install nginx
+RUN addgroup -g 101 -S nginx && \
+    adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx && \
+    apk --update --no-cache upgrade && \
+    apk --update add --no-cache \
+      openssl-dev \
+      pcre-dev \
+      zlib-dev \
+      wget \
+      build-base && \
+    mkdir /tmp/src && \
+    cd /tmp/src && \
+    wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+    wget -qO nginx-module-vts-${VTS_MODULE_VERSION}.tar.gz https://github.com/vozlt/nginx-module-vts/archive/v${VTS_MODULE_VERSION}.tar.gz && \
+    tar -xzf nginx-module-vts-${VTS_MODULE_VERSION}.tar.gz && \ 
+    tar -xzf nginx-${NGINX_VERSION}.tar.gz && \
+    cd nginx-${NGINX_VERSION} && \
+    ./configure \
+      --prefix=/etc/nginx \
+      --sbin-path=/usr/sbin/nginx \
+      --modules-path=/usr/lib/nginx/modules \
+      --conf-path=/etc/nginx/nginx.conf \
+      --error-log-path=/var/log/nginx/error.log \
+      --http-log-path=/var/log/nginx/access.log \
+      --pid-path=/var/run/nginx.pid \
+      --lock-path=/var/run/nginx.lock \
+      --http-client-body-temp-path=/var/cache/nginx/client_temp \
+      --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+      --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+      --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+      --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+      --user=nginx \
+      --group=nginx \
+      --with-http_ssl_module \
+      --with-http_realip_module \
+      --with-http_addition_module \
+      --with-http_sub_module \
+      --with-http_dav_module \
+      --with-http_flv_module \
+      --with-http_gunzip_module \
+      --with-http_gzip_static_module \
+      --with-http_random_index_module \
+      --with-http_secure_link_module \
+      --with-http_stub_status_module \
+      --with-http_auth_request_module \
+      --with-threads --with-stream \
+      --with-stream_ssl_module \
+      --with-http_slice_module \
+      --with-mail \
+      --with-mail_ssl_module \
+      --with-http_v2_module \
+      --with-cc-opt='-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2' \
+      --with-ld-opt='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--as-needed' \
+      --add-module=/tmp/src/nginx-module-vts-${VTS_MODULE_VERSION} && \
+    make && \
+    make install && \
+    apk del --purge \
+      build-base \
+      wget && \
+    cd / && \
+    rm -fr /tmp/src && \
+    mkdir -p /etc/nginx/conf.d /var/cache/nginx ${APP_DIR} && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /etc/nginx /var/cache/nginx /var/log/nginx /var/run/nginx.pid ${APP_DIR}
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Remove existing crontabs, if any.
+RUN rm -fr /var/spool/cron \
+	&& rm -fr /etc/crontabs \
+	&& rm -fr /etc/periodic
+
+# Remove all but a handful of admin commands.
+RUN find /sbin /usr/sbin \
+  ! -type d -a ! -name apk -a ! -name ln ! -name nginx \
+  -delete
+
+# Remove world-writeable permissions except for /tmp/
+RUN find / -xdev -type d -perm +0002 -exec chmod o-w {} + \
+	&& find / -xdev -type f -perm +0002 -exec chmod o-w {} + \
+	&& chmod 777 /tmp/ \
+  && chown $APP_USER:root /tmp/
+
+# Remove unnecessary accounts, excluding current app user and root
+RUN sed -i -r "/^($APP_USER|root|nobody)/!d" /etc/group \
+  && sed -i -r "/^($APP_USER|root|nobody)/!d" /etc/passwd
+
+# Remove interactive login shell for everybody
+RUN sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+# Disable password login for everybody
+RUN while IFS=: read -r username _; do passwd -l "$username"; done < /etc/passwd || true
+
+# Remove temp shadow,passwd,group
+RUN find /bin /etc /lib /sbin /usr -xdev -type f -regex '.*-$' -exec rm -f {} +
+
+# Ensure system dirs are owned by root and not writable by anybody else.
+RUN find /bin /etc /lib /sbin /usr -xdev -type d \
+  -exec chown root:root {} \; \
+  -exec chmod 0755 {} \;
+
+# Remove suid & sgid files
+RUN find /bin /etc /lib /sbin /usr -xdev -type f -a \( -perm +4000 -o -perm +2000 \) -delete
+
+# Remove dangerous commands
+RUN find /bin /etc /lib /sbin /usr -xdev \( \
+  -name hexdump -o \
+  -name chgrp -o \
+  -name chown -o \
+  -name ln -o \
+  -name od -o \
+  -name strings -o \
+  -name su \
+  -name sudo \
+  \) -delete
+
+# Remove init scripts since we do not use them.
+RUN rm -fr /etc/init.d /lib/rc /etc/conf.d /etc/inittab /etc/runlevels /etc/rc.conf /etc/logrotate.d
+
+# Remove kernel tunables
+RUN rm -fr /etc/sysctl* /etc/modprobe.d /etc/modules /etc/mdev.conf /etc/acpi
+
+# Remove root home dir
+RUN rm -fr /root
+
+# Remove fstab
+RUN rm -f /etc/fstab
+
+# Remove any symlinks that we broke during previous steps
+RUN find /bin /etc /lib /sbin /usr -xdev -type l -exec test ! -e {} \; -delete
+
+USER ${APP_USER}
+WORKDIR ${APP_DIR}
+
+ENTRYPOINT ["nginx"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,98 @@
+daemon off;
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+  worker_connections  1024;
+}
+
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  log_format json_logs '{ '
+    '"time_iso": "$time_iso8601",'
+
+    '"server_host": "$host",'
+    '"server_port": "$server_port",'
+    '"server_pid": "$pid",'
+
+    '"client_addr": {"remote_addr": "$remote_addr","http_x_forwarded_for": "$http_x_forwarded_for"},'
+    '"client_port": "$remote_port",'
+    '"client_user": "$remote_user",'
+
+    '"http_request_method": "$request_method",'
+    '"http_request_uri": "$request_uri",'
+    '"http_request_uri_normalized": "$uri",'
+    '"http_request_args": "$args",'
+    '"http_request_protocol": "$server_protocol",'
+    '"http_request_length": "$request_length",'
+    '"http_request_time": "$request_time",'
+
+    '"http_content_length": "$content_length",'
+    '"http_content_type": "$content_type",'
+
+    '"ssl_protocol": "$ssl_protocol",'
+    '"ssl_session_reused": "$ssl_session_reused",'
+
+    '"http_response_size": "$bytes_sent",'
+    '"http_response_body_size": "$body_bytes_sent",'
+
+    '"upstream_server": "$upstream_addr",'
+    '"upstream_connect_time": "$upstream_connect_time",'
+    '"upstream_header_time": "$upstream_header_time",'
+    '"upstream_response_time": "$upstream_response_time",'
+    '"upstream_response_length": "$upstream_response_length",'
+    '"upstream_status": "$upstream_status",'
+
+    '"http_status": "$status",'
+    '"http_referer": "$http_referer",'
+    '"http_user_agent": "$http_user_agent",'
+    '"X-Forwarded-Proto": "$scheme"'
+    ' }' '';
+
+  access_log  /dev/stdout  json_logs;
+
+  sendfile            on;
+  tcp_nopush          on;
+  server_tokens       off;
+
+  keepalive_timeout   65;
+
+  keepalive_requests  100000;
+  client_body_timeout 60;
+  send_timeout        60;
+  lingering_timeout   5;
+  tcp_nodelay         off;
+
+  gzip                on;
+  gzip_comp_level     2;
+  gzip_disable        msie6;
+  gzip_min_length     20;
+  gzip_http_version   1.1;
+  gzip_proxied        any;
+  gzip_types          text/plain text/xml text/css application/x-javascript;
+  gzip_vary           on;
+
+  vhost_traffic_status_zone;
+  vhost_traffic_status_dump /var/log/nginx/vts.db;
+  server {
+    listen 8000;
+    location /status {
+      vhost_traffic_status_bypass_limit on;
+      vhost_traffic_status_bypass_stats on;
+      vhost_traffic_status_display;
+      vhost_traffic_status_display_format html;
+    }
+  }
+
+  include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Add a hardened nginx image for use within the kubernetes cluster.

Since nginx runs as an unprivileged user it is advised to not bind the image on privileged ports.
The image is compiled with module `nginx-module-vts` so as to provide monitoring stats.